### PR TITLE
Fix counter blocks in MaliCounter

### DIFF
--- a/mali_counter.cpp
+++ b/mali_counter.cpp
@@ -191,8 +191,8 @@ MaliHWInfo get_mali_hw_info(const char *path)
 			hw_info.p_value = props.minor_revision;
 			for (uint32_t i = 0; i < props.num_core_groups; i++)
 				hw_info.core_mask |= props.core_mask[i];
-			hw_info.mp_count = __builtin_popcountll(hw_info.core_mask);
-			//hw_info.l2_slices = props.l2_slices;
+			hw_info.mp_count  = __builtin_popcountll(hw_info.core_mask);
+			hw_info.l2_slices = props.l2_slices;
 
 			close(fd);
 		}
@@ -233,7 +233,8 @@ void MaliCounter::init()
 
 	MaliHWInfo hw_info = get_mali_hw_info(_device);
 
-	_num_cores = hw_info.mp_count;
+	_num_cores     = hw_info.mp_count;
+	_num_l2_slices = hw_info.l2_slices;
 
 	_fd = open(_device, O_RDWR | O_CLOEXEC | O_NONBLOCK);        // NOLINT
 

--- a/mali_counter.cpp
+++ b/mali_counter.cpp
@@ -448,7 +448,7 @@ const uint32_t *MaliCounter::get_counters(mali_userspace::MaliCounterBlockName b
 		case mali_userspace::MALI_NAME_BLOCK_MMU:
 			if (index < 0 || index >= _num_l2_slices)
 			{
-				throw std::runtime_error("Invalid core number.");
+				throw std::runtime_error("Invalid slice number.");
 			}
 
 			// If an MMU counter is selected, index refers to the MMU slice

--- a/mali_counter.h
+++ b/mali_counter.h
@@ -61,6 +61,10 @@ class MaliCounter : public Instrument
 	const uint32_t *get_counters(mali_userspace::MaliCounterBlockName block, int index = -1) const;
 	int             find_counter_index_by_name(mali_userspace::MaliCounterBlockName block, const char *name);
 
+	const std::vector<const std::pair<const char *, const char *>> _jm_counter_names{
+	    {"GPU_ACTIVE", "cycles"}, {"JS0_JOBS", "jobs"}, {"JS1_JOBS", "jobs"}};
+	const std::vector<const std::pair<const char *, const char *>> _mmu_counter_names{
+	    {"L2_READ_LOOKUP", "cache lookups"}, {"L2_EXT_READ", "transactions"}, {"L2_EXT_AR_STALL", "stall cycles"}, {"L2_WRITE_LOOKUP", "cache lookups"}, {"L2_EXT_WRITE", "transactions"}, {"L2_EXT_W_STALL", "stall cycles"}, {"L2_EXT_READ_BEATS", "bus cycles"}, {"L2_EXT_WRITE_BEATS", "bus cycles"}};
 	std::map<std::string, Measurement> _counters{};
 
 	uint64_t _start_time{0};

--- a/mali_counter.h
+++ b/mali_counter.h
@@ -68,6 +68,7 @@ class MaliCounter : public Instrument
 
 	const char *const  _device{"/dev/mali0"};
 	int                _num_cores{0};
+	int                _num_l2_slices{0};
 	uint32_t           _hw_ver{0};
 	int                _buffer_count{16};
 	size_t             _buffer_size{0};

--- a/mali_counter.h
+++ b/mali_counter.h
@@ -62,9 +62,18 @@ class MaliCounter : public Instrument
 	int             find_counter_index_by_name(mali_userspace::MaliCounterBlockName block, const char *name);
 
 	const std::vector<const std::pair<const char *, const char *>> _jm_counter_names{
-	    {"GPU_ACTIVE", "cycles"}, {"JS0_JOBS", "jobs"}, {"JS1_JOBS", "jobs"}};
+	    {"GPU_ACTIVE", "cycles"},
+	    {"JS0_JOBS", "jobs"},
+	    {"JS1_JOBS", "jobs"}};
 	const std::vector<const std::pair<const char *, const char *>> _mmu_counter_names{
-	    {"L2_READ_LOOKUP", "cache lookups"}, {"L2_EXT_READ", "transactions"}, {"L2_EXT_AR_STALL", "stall cycles"}, {"L2_WRITE_LOOKUP", "cache lookups"}, {"L2_EXT_WRITE", "transactions"}, {"L2_EXT_W_STALL", "stall cycles"}, {"L2_EXT_READ_BEATS", "bus cycles"}, {"L2_EXT_WRITE_BEATS", "bus cycles"}};
+	    {"L2_READ_LOOKUP", "cache lookups"},
+	    {"L2_EXT_READ", "transactions"},
+	    {"L2_EXT_AR_STALL", "stall cycles"},
+	    {"L2_WRITE_LOOKUP", "cache lookups"},
+	    {"L2_EXT_WRITE", "transactions"},
+	    {"L2_EXT_W_STALL", "stall cycles"},
+	    {"L2_EXT_READ_BEATS", "bus cycles"},
+	    {"L2_EXT_WRITE_BEATS", "bus cycles"}};
 	std::map<std::string, Measurement> _counters{};
 
 	uint64_t _start_time{0};

--- a/mali_counter.h
+++ b/mali_counter.h
@@ -58,7 +58,7 @@ class MaliCounter : public Instrument
 	void            sample_counters();
 	void            wait_next_event();
 	const uint32_t *get_counters() const;
-	const uint32_t *get_counters(mali_userspace::MaliCounterBlockName block, int core = -1) const;
+	const uint32_t *get_counters(mali_userspace::MaliCounterBlockName block, int index = -1) const;
 	int             find_counter_index_by_name(mali_userspace::MaliCounterBlockName block, const char *name);
 
 	std::map<std::string, Measurement> _counters{};

--- a/pmu_counter.cpp
+++ b/pmu_counter.cpp
@@ -43,6 +43,7 @@ void PMUCounter::stop()
 	try
 	{
 		_cycles = _pmu_cycles.get_value<long long>();
+		_pmu_cycles.reset();
 	}
 	catch (const std::runtime_error &)
 	{
@@ -52,6 +53,7 @@ void PMUCounter::stop()
 	try
 	{
 		_instructions = _pmu_instructions.get_value<long long>();
+		_pmu_instructions.reset();
 	}
 	catch (const std::runtime_error &)
 	{
@@ -61,6 +63,7 @@ void PMUCounter::stop()
 	try
 	{
 		_cache_references = _pmu_cache_references.get_value<long long>();
+		_pmu_cache_references.reset();
 	}
 	catch (const std::runtime_error &)
 	{
@@ -70,6 +73,7 @@ void PMUCounter::stop()
 	try
 	{
 		_cache_misses = _pmu_cache_misses.get_value<long long>();
+		_pmu_cache_misses.reset();
 	}
 	catch (const std::runtime_error &)
 	{
@@ -79,6 +83,7 @@ void PMUCounter::stop()
 	try
 	{
 		_branch_instructions = _pmu_branch_instructions.get_value<long long>();
+		_pmu_branch_instructions.reset();
 	}
 	catch (const std::runtime_error &)
 	{
@@ -88,6 +93,7 @@ void PMUCounter::stop()
 	try
 	{
 		_branch_misses = _pmu_branch_misses.get_value<long long>();
+		_pmu_branch_misses.reset();
 	}
 	catch (const std::runtime_error &)
 	{


### PR DESCRIPTION
These changes fix the values read from MaliCounter. The changes are transparent to the application.

Main change:
* L2 slices are taken into account when computing counter block offsets

Plus:
* Counter names are defined in a single place for easier maintainability
* PMU counters are reset on `stop()` for consistency with Mali counters - this way they can all be read by calling `stop()` periodically