### PR TITLE
Fix std::vector with const std::pair

### DIFF
--- a/mali_counter.h
+++ b/mali_counter.h
@@ -30,6 +30,7 @@
 
 #include <map>
 #include <vector>
+#include <algorithm>
 
 /** Instrument implementation for mali hw counters. */
 class MaliCounter : public Instrument
@@ -61,11 +62,11 @@ class MaliCounter : public Instrument
 	const uint32_t *get_counters(mali_userspace::MaliCounterBlockName block, int index = -1) const;
 	int             find_counter_index_by_name(mali_userspace::MaliCounterBlockName block, const char *name);
 
-	const std::vector<const std::pair<const char *, const char *>> _jm_counter_names{
+	const std::vector<std::pair<const char *, const char *>> _jm_counter_names{
 	    {"GPU_ACTIVE", "cycles"},
 	    {"JS0_JOBS", "jobs"},
 	    {"JS1_JOBS", "jobs"}};
-	const std::vector<const std::pair<const char *, const char *>> _mmu_counter_names{
+	const std::vector<std::pair<const char *, const char *>> _mmu_counter_names{
 	    {"L2_READ_LOOKUP", "cache lookups"},
 	    {"L2_EXT_READ", "transactions"},
 	    {"L2_EXT_AR_STALL", "stall cycles"},


### PR DESCRIPTION
Minor fix to fix compilation with gnu g++ 6.2.1 (armv7l).

Signed-off-by: Saulo Aldighieri Moraes <saulo@ g...com>