### PR TITLE
Fix invalid fd on PMU counter creation

### DIFF
--- a/vendor/arm/pmu/pmu_counter.cpp
+++ b/vendor/arm/pmu/pmu_counter.cpp
@@ -74,7 +74,7 @@ void PmuCounter::open(const perf_event_attr &perf_config)
 	const int result = ioctl(_fd, PERF_EVENT_IOC_ENABLE, 0);
 	if (result == -1)
 	{
-		throw std::runtime_error("Failed to enable PMU counter: " + std::to_string(errno));
+		throw std::runtime_error("Failed to enable PMU counter: " + std::string(strerror(errno)));
 	}
 }
 

--- a/vendor/arm/pmu/pmu_counter.h
+++ b/vendor/arm/pmu/pmu_counter.h
@@ -95,7 +95,7 @@ T PmuCounter::get_value() const
 
 	if (result == -1)
 	{
-		throw std::runtime_error("Can't get PMU counter value: " + std::to_string(errno));
+		throw std::runtime_error("Can't get PMU counter value: " + std::string(strerror(errno)));
 	}
 
 	return static_cast<T>(value);

--- a/vendor/arm/pmu/pmu_profiler.cpp
+++ b/vendor/arm/pmu/pmu_profiler.cpp
@@ -48,8 +48,12 @@ PmuProfiler::PmuProfiler(const CpuCounterSet &enabled_counters) :
 		{
 			try
 			{
-				auto pmu_counter = pmu_counters_.emplace(counter, PmuCounter{pmu_config->second});
-				pmu_counters_[counter].get_value<double>();
+				// Create a PMU counter with the specified configuration
+				auto pmu_counter_res = pmu_counters_.emplace(counter, pmu_config->second);
+
+				// Try reading a value from the counter to check that it opened correctly
+				auto &pmu_counter = pmu_counter_res.first->second;
+				pmu_counter.get_value<double>();
 
 				// PMU counter is created and can retrieve values
 				available_counters_.insert(counter);

--- a/vendor/arm/pmu/pmu_profiler.cpp
+++ b/vendor/arm/pmu/pmu_profiler.cpp
@@ -61,6 +61,7 @@ PmuProfiler::PmuProfiler(const CpuCounterSet &enabled_counters) :
 			catch (const std::runtime_error &e)
 			{
 				// PMU counter initialization failed
+				HWCPIPE_LOG("%s", e.what());
 			}
 		}
 	}


### PR DESCRIPTION
The issue was due to the call to ` emplace` creating a temporary PMU counter. When the temporary object was destroyed, the corresponding file descriptor was closed.

Also improved logging for easier debugging of similar issues.