### PR TITLE
Make strerror available in the header for PmuCounter

### DIFF
--- a/vendor/arm/pmu/pmu_counter.h
+++ b/vendor/arm/pmu/pmu_counter.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstring>
 #include <errno.h>
 #include <linux/perf_event.h>
 #include <stdexcept>
@@ -95,7 +96,7 @@ T PmuCounter::get_value() const
 
 	if (result == -1)
 	{
-		throw std::runtime_error("Can't get PMU counter value: " + std::string(strerror(errno)));
+		throw std::runtime_error("Can't get PMU counter value: " + std::string(std::strerror(errno)));
 	}
 
 	return static_cast<T>(value);


### PR DESCRIPTION
This fixes an error with some compilers in the templated function `get_value`:

> there are no arguments to 'strerror' that depend on a template
> parameter, so a declaration of 'strerror' must be available