### PR TITLE
Fix a bug with explicit constructor and emplace

### DIFF
--- a/vendor/arm/pmu/pmu_profiler.cpp
+++ b/vendor/arm/pmu/pmu_profiler.cpp
@@ -49,7 +49,7 @@ PmuProfiler::PmuProfiler(const CpuCounterSet &enabled_counters) :
 			try
 			{
 				// Create a PMU counter with the specified configuration
-				auto pmu_counter_res = pmu_counters_.emplace(counter, pmu_config->second);
+				auto pmu_counter_res = pmu_counters_.emplace(counter, PmuCounter{pmu_config->second});
 
 				// Try reading a value from the counter to check that it opened correctly
 				auto &pmu_counter = pmu_counter_res.first->second;


### PR DESCRIPTION
This caused the build to fail on GCC 5.4.