### PR TITLE
Remove unused private variable.

### DIFF
--- a/hwcpipe.h
+++ b/hwcpipe.h
@@ -79,8 +79,6 @@ class HWCPipe
 	}
 
   private:
-	bool running_{false};
-
 	std::unique_ptr<CpuProfiler> cpu_profiler_{};
 	std::unique_ptr<GpuProfiler> gpu_profiler_{};
 

--- a/vendor/arm/mali/mali_profiler.h
+++ b/vendor/arm/mali/mali_profiler.h
@@ -91,8 +91,6 @@ class MaliProfiler : public GpuProfiler
 	    GpuCounter::ExternalMemoryWriteBytes,
 	};
 
-	bool running_{false};
-
 	typedef std::function<double(void)>                             MaliValueGetter;
 	std::unordered_map<GpuCounter, MaliValueGetter, GpuCounterHash> mappings_{};
 

--- a/vendor/arm/pmu/pmu_profiler.h
+++ b/vendor/arm/pmu/pmu_profiler.h
@@ -68,7 +68,6 @@ class PmuProfiler : public CpuProfiler
 	    CpuCounter::BranchInstructions,
 	    CpuCounter::BranchMisses};
 
-	bool            running_{false};
 	CpuMeasurements measurements_{};
 	CpuMeasurements prev_measurements_{};
 


### PR DESCRIPTION
Fixes gcc warning with -Wunused-private-field