### PR TITLE
Workaround for Android build issue with JSON library used

### DIFF
--- a/hwcpipe.cpp
+++ b/hwcpipe.cpp
@@ -25,7 +25,7 @@
 #include "hwcpipe.h"
 #include "hwcpipe_log.h"
 
-#ifdef linux
+#ifdef __linux__
 #	include "vendor/arm/pmu/pmu_profiler.h"
 #	include "vendor/arm/mali/mali_profiler.h"
 #endif
@@ -171,7 +171,7 @@ void HWCPipe::stop()
 void HWCPipe::create_profilers(CpuCounterSet enabled_cpu_counters, GpuCounterSet enabled_gpu_counters)
 {
 	// Automated platform detection
-#ifdef linux
+#ifdef __linux__
 	try
 	{
 		cpu_profiler_ = std::unique_ptr<PmuProfiler>(new PmuProfiler(enabled_cpu_counters));

--- a/hwcpipe.cpp
+++ b/hwcpipe.cpp
@@ -30,13 +30,16 @@
 #	include "vendor/arm/mali/mali_profiler.h"
 #endif
 
+#ifndef HWCPIPE_NO_JSON
 #include <json.hpp>
 using json = nlohmann::json;
+#endif
 
 #include <memory>
 
 namespace hwcpipe
 {
+#ifndef HWCPIPE_NO_JSON
 HWCPipe::HWCPipe(const char *json_string)
 {
 	auto json = json::parse(json_string);
@@ -79,6 +82,7 @@ HWCPipe::HWCPipe(const char *json_string)
 
 	create_profilers(std::move(enabled_cpu_counters), std::move(enabled_gpu_counters));
 }
+#endif
 
 HWCPipe::HWCPipe(CpuCounterSet enabled_cpu_counters, GpuCounterSet enabled_gpu_counters)
 {

--- a/hwcpipe.h
+++ b/hwcpipe.h
@@ -42,8 +42,10 @@ struct Measurements
 class HWCPipe
 {
   public:
+#ifndef HWCPIPE_NO_JSON
 	// Initializes HWCPipe via a JSON configuration string
 	explicit HWCPipe(const char *json_string);
+#endif
 
 	// Initializes HWCPipe with the specified counters
 	HWCPipe(CpuCounterSet enabled_cpu_counters, GpuCounterSet enabled_gpu_counters);


### PR DESCRIPTION
The used JSON library will not build on very old Android versions. Add a define to not use it.