### PR TITLE
fix missing stdexcept include in mali profiler

### DIFF
--- a/vendor/arm/mali/mali_profiler.cpp
+++ b/vendor/arm/mali/mali_profiler.cpp
@@ -26,6 +26,7 @@
 #include "hwcpipe_log.h"
 
 #include <algorithm>
+#include <stdexcept>
 
 using mali_userspace::MALI_NAME_BLOCK_JM;
 using mali_userspace::MALI_NAME_BLOCK_MMU;


### PR DESCRIPTION
this cpp file uses std::runtime_error and thus requires stdexcept header

seen when building https://github.com/KhronosGroup/Vulkan-Samples on a Fedora 32 host, using stock GCC 10.1.1