### PR TITLE
Replaced exceptions with last error message

### DIFF
--- a/hwcpipe.h
+++ b/hwcpipe.h
@@ -32,6 +32,14 @@
 
 namespace hwcpipe
 {
+const char* get_last_error()
+{
+	extern const char *error_msg;
+	const char *       err = error_msg;
+	error_msg              = nullptr;
+	return err;
+}
+
 struct Measurements
 {
 	const CpuMeasurements *cpu{nullptr};
@@ -71,11 +79,11 @@ class HWCPipe
 	// Stops the active profiling session
 	void stop();
 
-	const CpuProfiler *cpu_profiler()
+	CpuProfiler *cpu_profiler()
 	{
 		return cpu_profiler_.get();
 	}
-	const GpuProfiler *gpu_profiler()
+	GpuProfiler *gpu_profiler()
 	{
 		return gpu_profiler_.get();
 	}

--- a/vendor/arm/pmu/pmu_counter.cpp
+++ b/vendor/arm/pmu/pmu_counter.cpp
@@ -30,6 +30,11 @@
 #include <sys/ioctl.h>
 #include <linux/version.h>
 
+namespace hwcpipe
+{
+extern const char *error_msg;
+}
+
 PmuCounter::PmuCounter() :
     _perf_config()
 {
@@ -69,13 +74,14 @@ void PmuCounter::open(const perf_event_attr &perf_config)
 
 	if (_fd < 0)
 	{
-		throw std::runtime_error("perf_event_open failed. Counter ID: " + config_to_str(_perf_config));
+		hwcpipe::error_msg = "perf_event_open failed.";
+		return;
 	}
 
 	const int result = ioctl(_fd, PERF_EVENT_IOC_ENABLE, 0);
 	if (result == -1)
 	{
-		throw std::runtime_error("Failed to enable PMU counter: " + std::string(strerror(errno)));
+		hwcpipe::error_msg = "Failed to enable PMU counter.";
 	}
 }
 
@@ -91,12 +97,6 @@ void PmuCounter::close()
 bool PmuCounter::reset()
 {
 	const int result = ioctl(_fd, PERF_EVENT_IOC_RESET, 0);
-
-	if (result == -1)
-	{
-		throw std::runtime_error("Failed to reset PMU counter: " + std::string(std::strerror(errno)));
-	}
-
 	return result != -1;
 }
 

--- a/vendor/arm/pmu/pmu_counter.h
+++ b/vendor/arm/pmu/pmu_counter.h
@@ -124,10 +124,5 @@ T PmuCounter::get_value() const
 	long long     value{};
 	const ssize_t result = read(_fd, &value, sizeof(long long));
 
-	if (result == -1)
-	{
-		throw std::runtime_error("Can't get PMU counter value: " + std::string(std::strerror(errno)));
-	}
-
 	return static_cast<T>(value);
 }


### PR DESCRIPTION
This library's target audience are game developers. Exceptions are not used in C++ game development at all, it's a standard de-facto. There's some limited exception handling withing this library, but unfortunately it doesn't handle everything and allows exceptions to leave module's boundaries. I tried to keep it, however in my integration it would still crash and wouldn't call libraries exception handler. Might be a bug in Android SDK.