### PR TITLE
Fixed transfer of memory ownership across the boundaries of the lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,9 @@ if(UNIX AND NOT APPLE)
         vendor/arm/pmu/pmu_profiler.cpp)
 endif()
 
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fvisibility=hidden -fvisibility-inlines-hidden")
+set (CMAKE_SHARED_LINKER_FLAGS  "${CMAKE_SHARED_LINKER_FLAGS} -shared")
+
 source_group("\\" FILES ${PROJECT_FILES})
 
 add_library(${PROJECT_NAME} STATIC ${PROJECT_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,12 +44,12 @@ if(UNIX AND NOT APPLE)
         vendor/arm/pmu/pmu_profiler.cpp)
 endif()
 
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fvisibility=hidden -fvisibility-inlines-hidden")
-set (CMAKE_SHARED_LINKER_FLAGS  "${CMAKE_SHARED_LINKER_FLAGS} -shared")
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 
 source_group("\\" FILES ${PROJECT_FILES})
 
-add_library(${PROJECT_NAME} STATIC ${PROJECT_FILES})
+add_library(${PROJECT_NAME} SHARED ${PROJECT_FILES})
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,3 +56,5 @@ target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(${PROJECT_NAME} PUBLIC third_party)
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+
+generate_export_header(${PROJECT_NAME} EXPORT_FILE_NAME ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}_export.h)

--- a/cpu_profiler.h
+++ b/cpu_profiler.h
@@ -58,26 +58,7 @@ enum class CpuCounter
 };
 
 // Mapping from CPU counter names to enum values. Used for JSON initialization.
-const std::unordered_map<std::string, CpuCounter> cpu_counter_names{
-    {"Cycles", CpuCounter::Cycles},
-    {"Instructions", CpuCounter::Instructions},
-    {"CacheReferences", CpuCounter::CacheReferences},
-    {"CacheMisses", CpuCounter::CacheMisses},
-    {"BranchInstructions", CpuCounter::BranchInstructions},
-    {"BranchMisses", CpuCounter::BranchMisses},
-
-    {"L1Accesses", CpuCounter::L1Accesses},
-    {"InstrRetired", CpuCounter::InstrRetired},
-    {"L2Accesses", CpuCounter::L2Accesses},
-    {"L3Accesses", CpuCounter::L3Accesses},
-    {"BusReads", CpuCounter::BusReads},
-    {"BusWrites", CpuCounter::BusWrites},
-    {"MemReads", CpuCounter::MemReads},
-    {"MemWrites", CpuCounter::MemWrites},
-    {"ASESpec", CpuCounter::ASESpec},
-    {"VFPSpec", CpuCounter::VFPSpec},
-    {"CryptoSpec", CpuCounter::CryptoSpec},
-};
+extern const std::unordered_map<std::string, CpuCounter> cpu_counter_names;
 
 // A hash function for CpuCounter values
 struct CpuCounterHash
@@ -95,6 +76,7 @@ struct CpuCounterInfo
 	std::string unit;
 };
 
+/*
 // Mapping from each counter to its corresponding information (description and unit)
 const std::unordered_map<CpuCounter, CpuCounterInfo, CpuCounterHash> cpu_counter_info{
     {CpuCounter::Cycles, {"Number of CPU cycles", "cycles"}},
@@ -116,6 +98,7 @@ const std::unordered_map<CpuCounter, CpuCounterInfo, CpuCounterHash> cpu_counter
     {CpuCounter::VFPSpec, {"Speculatively executed floating point operations", "operations"}},
     {CpuCounter::CryptoSpec, {"Speculatively executed cryptographic operations", "operations"}},
 };
+*/
 
 typedef std::unordered_set<CpuCounter, CpuCounterHash> CpuCounterSet;
 typedef std::unordered_map<CpuCounter, Value, CpuCounterHash>
@@ -134,7 +117,7 @@ class CpuProfiler
 	virtual const CpuCounterSet &supported_counters() const = 0;
 
 	// Sets the enabled counters after initialization
-	virtual void set_enabled_counters(CpuCounterSet counters) = 0;
+	virtual void set_enabled_counters(const CpuCounterSet& counters) = 0;
 
 	// Starts a profiling session
 	virtual void run() = 0;

--- a/gpu_profiler.h
+++ b/gpu_profiler.h
@@ -72,40 +72,7 @@ enum class GpuCounter
 };
 
 // Mapping from GPU counter names to enum values. Used for JSON initialization.
-const std::unordered_map<std::string, GpuCounter> gpu_counter_names{
-    {"GpuCycles", GpuCounter::GpuCycles},
-    {"VertexComputeCycles", GpuCounter::VertexComputeCycles},
-    {"FragmentCycles", GpuCounter::FragmentCycles},
-    {"TilerCycles", GpuCounter::TilerCycles},
-
-    {"VertexComputeJobs", GpuCounter::VertexComputeJobs},
-    {"Tiles", GpuCounter::Tiles},
-    {"TransactionEliminations", GpuCounter::TransactionEliminations},
-    {"FragmentJobs", GpuCounter::FragmentJobs},
-    {"Pixels", GpuCounter::Pixels},
-
-    {"EarlyZTests", GpuCounter::EarlyZTests},
-    {"EarlyZKilled", GpuCounter::EarlyZKilled},
-    {"LateZTests", GpuCounter::LateZTests},
-    {"LateZKilled", GpuCounter::LateZKilled},
-
-    {"Instructions", GpuCounter::Instructions},
-    {"DivergedInstructions", GpuCounter::DivergedInstructions},
-
-    {"ShaderCycles", GpuCounter::ShaderCycles},
-    {"ShaderArithmeticCycles", GpuCounter::ShaderArithmeticCycles},
-    {"ShaderLoadStoreCycles", GpuCounter::ShaderLoadStoreCycles},
-    {"ShaderTextureCycles", GpuCounter::ShaderTextureCycles},
-
-    {"CacheReadLookups", GpuCounter::CacheReadLookups},
-    {"CacheWriteLookups", GpuCounter::CacheWriteLookups},
-    {"ExternalMemoryReadAccesses", GpuCounter::ExternalMemoryReadAccesses},
-    {"ExternalMemoryWriteAccesses", GpuCounter::ExternalMemoryWriteAccesses},
-    {"ExternalMemoryReadStalls", GpuCounter::ExternalMemoryReadStalls},
-    {"ExternalMemoryWriteStalls", GpuCounter::ExternalMemoryWriteStalls},
-    {"ExternalMemoryReadBytes", GpuCounter::ExternalMemoryReadBytes},
-    {"ExternalMemoryWriteBytes", GpuCounter::ExternalMemoryWriteBytes},
-};
+extern const std::unordered_map<std::string, GpuCounter> gpu_counter_names;
 
 // A hash function for GpuCounter values
 struct GpuCounterHash
@@ -123,6 +90,7 @@ struct GpuCounterInfo
 	std::string unit;
 };
 
+/*
 // Mapping from each counter to its corresponding information (description and unit)
 const std::unordered_map<GpuCounter, GpuCounterInfo, GpuCounterHash> gpu_counter_info{
     {GpuCounter::GpuCycles, {"Number of GPU cycles", "cycles"}},
@@ -158,6 +126,7 @@ const std::unordered_map<GpuCounter, GpuCounterInfo, GpuCounterHash> gpu_counter
     {GpuCounter::ExternalMemoryReadBytes, {"Bytes read to external memory", "B"}},
     {GpuCounter::ExternalMemoryWriteBytes, {"Bytes written to external memory", "B"}},
 };
+*/
 
 typedef std::unordered_set<GpuCounter, GpuCounterHash>        GpuCounterSet;
 typedef std::unordered_map<GpuCounter, Value, GpuCounterHash> GpuMeasurements;
@@ -175,7 +144,7 @@ class GpuProfiler
 	virtual const GpuCounterSet &supported_counters() const = 0;
 
 	// Sets the enabled counters after initialization
-	virtual void set_enabled_counters(GpuCounterSet counters) = 0;
+	virtual void set_enabled_counters(const GpuCounterSet& counters) = 0;
 
 	// Starts a profiling session
 	virtual void run() = 0;

--- a/hwcpipe.h
+++ b/hwcpipe.h
@@ -30,7 +30,7 @@
 #include <functional>
 #include <memory>
 
-#define API_CALL __attribute__((visibility("default")))
+#include "hwcpipe_export.h"
 
 namespace hwcpipe
 {
@@ -41,7 +41,7 @@ struct Measurements
 };
 
 /** A class that collects CPU/GPU performance data. */
-class API_CALL HWCPipe
+class HWCPIPE_EXPORT HWCPipe
 {
   public:
 #ifndef HWCPIPE_NO_JSON

--- a/hwcpipe.h
+++ b/hwcpipe.h
@@ -30,6 +30,8 @@
 #include <functional>
 #include <memory>
 
+#define API_CALL __attribute__((visibility("default")))
+
 namespace hwcpipe
 {
 struct Measurements
@@ -39,7 +41,7 @@ struct Measurements
 };
 
 /** A class that collects CPU/GPU performance data. */
-class HWCPipe
+class API_CALL HWCPipe
 {
   public:
 #ifndef HWCPIPE_NO_JSON
@@ -48,16 +50,16 @@ class HWCPipe
 #endif
 
 	// Initializes HWCPipe with the specified counters
-	HWCPipe(CpuCounterSet enabled_cpu_counters, GpuCounterSet enabled_gpu_counters);
+	HWCPipe(const CpuCounterSet& enabled_cpu_counters, const GpuCounterSet& enabled_gpu_counters);
 
 	// Initializes HWCPipe with a default set of counters
 	HWCPipe();
 
 	// Sets the enabled counters for the CPU profiler
-	void set_enabled_cpu_counters(CpuCounterSet counters);
+	void set_enabled_cpu_counters(const CpuCounterSet& counters);
 
 	// Sets the enabled counters for the GPU profiler
-	void set_enabled_gpu_counters(GpuCounterSet counters);
+	void set_enabled_gpu_counters(const GpuCounterSet& counters);
 
 	// Starts a profiling session
 	void run();
@@ -84,7 +86,7 @@ class HWCPipe
 	std::unique_ptr<CpuProfiler> cpu_profiler_{};
 	std::unique_ptr<GpuProfiler> gpu_profiler_{};
 
-	void create_profilers(CpuCounterSet enabled_cpu_counters, GpuCounterSet enabled_gpu_counters);
+	void create_profilers(const CpuCounterSet& enabled_cpu_counters, const GpuCounterSet& enabled_gpu_counters);
 };
 
 }        // namespace hwcpipe

--- a/vendor/arm/mali/mali_profiler.h
+++ b/vendor/arm/mali/mali_profiler.h
@@ -50,9 +50,9 @@ class MaliProfiler : public GpuProfiler
 		return supported_counters_;
 	};
 
-	virtual void set_enabled_counters(GpuCounterSet counters) override
+	virtual void set_enabled_counters(const GpuCounterSet& counters) override
 	{
-		enabled_counters_ = std::move(counters);
+		enabled_counters_ = counters;
 	};
 
 	virtual void                   run() override;

--- a/vendor/arm/pmu/pmu_profiler.h
+++ b/vendor/arm/pmu/pmu_profiler.h
@@ -47,9 +47,9 @@ class PmuProfiler : public CpuProfiler
 		return supported_counters_;
 	};
 
-	virtual void set_enabled_counters(CpuCounterSet counters) override
+	virtual void set_enabled_counters(const CpuCounterSet& counters) override
 	{
-		enabled_counters_ = std::move(counters);
+		enabled_counters_ = counters;
 	};
 
 	virtual void                   run() override;


### PR DESCRIPTION
This change fixes transfer of memory ownership across the boundaries of the lib + links with dynamic c++ lib by default.
We had a problem when we overrided new and delete operators and memory for those unordered_sets was allocated by our allocator, but it was freed in the lib by system allocator which led to a crash.