### PR TITLE
Fix the bus width value used for bandwidth calculations

### DIFF
--- a/hwcpipe/include/hwcpipe/sampler.hpp
+++ b/hwcpipe/include/hwcpipe/sampler.hpp
@@ -582,7 +582,7 @@ class sampler : private detail::expression::context {
     }
 
     HWCP_NODISCARD double get_mali_config_ext_bus_byte_size() const override {
-        return static_cast<double>(constants_.axi_bus_width) / static_cast<double>(sizeof(char));
+        return static_cast<double>(constants_.axi_bus_width) / 8.0;
     }
 
     HWCP_NODISCARD double get_mali_config_shader_core_count() const override {


### PR DESCRIPTION
Fix for [issue #68](https://github.com/ARM-software/HWCPipe/issues/68)