### PR TITLE
Add missing standard header

### DIFF
--- a/backend/device/include/device/handle.hpp
+++ b/backend/device/include/device/handle.hpp
@@ -32,6 +32,7 @@
 
 #include <device/api.hpp>
 
+#include <cstdint>
 #include <memory>
 
 namespace hwcpipe {


### PR DESCRIPTION
Add a missing header required for `uint32_t` (fails compilation in GCC 15)