### PR TITLE
modify the enum to a fixed size

### DIFF
--- a/backend/device/src/device/handle_impl.hpp
+++ b/backend/device/src/device/handle_impl.hpp
@@ -44,7 +44,7 @@ template <typename syscall_iface_t>
 class handle_impl : public handle, private syscall_iface_t {
   public:
     /** Determines how descriptor should be treated. */
-    enum class mode {
+    enum class mode : uint8_t {
         /** The descriptor is closed at destruction time. */
         internal,
         /** the descriptor is kept open at destruction time. */

--- a/backend/device/src/device/hwcnt/sampler/base/backend.hpp
+++ b/backend/device/src/device/hwcnt/sampler/base/backend.hpp
@@ -62,7 +62,7 @@ class backend : public detail::backend, public reader, private syscall_iface_t {
     ~backend() override { get_syscall_iface().close(fd_); }
 
     /** Sampler type. */
-    enum class sampler_type {
+    enum class sampler_type : uint8_t {
         /** Manual sampler. */
         manual,
         /** Periodic sampler. */

--- a/backend/device/src/device/hwcnt/sampler/vinstr/sample_layout.hpp
+++ b/backend/device/src/device/hwcnt/sampler/vinstr/sample_layout.hpp
@@ -42,7 +42,7 @@ namespace sampler {
 namespace vinstr {
 
 /** Sample layout type. */
-enum class sample_layout_type {
+enum class sample_layout_type : uint8_t {
     /** v4 layout type. */
     v4,
     /** v5 layout or newer.*/

--- a/backend/device/src/device/ioctl/kbase/commands.hpp
+++ b/backend/device/src/device/ioctl/kbase/commands.hpp
@@ -41,7 +41,7 @@ constexpr auto iface_number = 0x80;
 namespace command {
 
 /** Commands describing kbase ioctl interface. */
-enum command_type {
+enum class command_type : uintptr_t {
     /** Check version compatibility between JM kernel and userspace. */
     version_check_jm = _IOWR(iface_number, 0x0, ::hwcpipe::device::ioctl::kbase::version_check),
     /** Check version compatibility between CSF kernel and userspace. */

--- a/backend/device/src/device/ioctl/kbase_pre_r21/commands.hpp
+++ b/backend/device/src/device/ioctl/kbase_pre_r21/commands.hpp
@@ -41,7 +41,7 @@ constexpr auto iface_number = 0x80;
 namespace command {
 
 /** Commands describing kbase_pre_r21 ioctl interface. */
-enum command_type {
+enum command_type : uintptr_t {
     /** Check version compatibility between JM kernel and userspace. */
     version_check = _IOWR(iface_number, 0x0, ::hwcpipe::device::ioctl::kbase_pre_r21::version_check_args),
     /** Set kernel context creation flags. */

--- a/backend/device/src/device/ioctl/kinstr_prfcnt/commands.hpp
+++ b/backend/device/src/device/ioctl/kinstr_prfcnt/commands.hpp
@@ -41,7 +41,7 @@ constexpr auto iface_number = 0xbf;
 namespace command {
 
 /** Commands describing kinstr_prfcnt ioctl interface. */
-enum command_type {
+enum command_type : uintptr_t {
     /** Issue command. */
     issue_command = _IOW(iface_number, 0x0, ::hwcpipe::device::ioctl::kinstr_prfcnt::control_cmd),
     /** Get sample. */

--- a/backend/device/src/device/ioctl/vinstr/commands.hpp
+++ b/backend/device/src/device/ioctl/vinstr/commands.hpp
@@ -41,7 +41,7 @@ constexpr auto iface_number = 0xbe;
 namespace command {
 
 /** Commands describing vinstr ioctl interface. */
-enum command_type {
+enum command_type : uintptr_t {
     /** Get HW version. */
     get_hwver = _IOR(iface_number, 0x0, uint32_t),
     /** Get HWCNT dump buffer size. */

--- a/backend/device/src/device/kbase_version.hpp
+++ b/backend/device/src/device/kbase_version.hpp
@@ -46,7 +46,7 @@ namespace hwcpipe {
 namespace device {
 
 /** Kbase ioctl interface type. */
-enum class ioctl_iface_type {
+enum class ioctl_iface_type : uint32_t {
     /** Pre R21 release Job manager kernel. */
     jm_pre_r21,
     /** Post R21 release Job manager kernel. */

--- a/hwcpipe/include/hwcpipe/hwcpipe_counter.h
+++ b/hwcpipe/include/hwcpipe/hwcpipe_counter.h
@@ -6,10 +6,11 @@
 
 #ifndef HWCPIPE_COUNTER_H
 #define HWCPIPE_COUNTER_H
+#include <cstdint>
 
 // NOLINTBEGIN(readability-identifier-naming)
 // all possible counters
-typedef enum hwcpipe_counter {
+typedef enum class hwcpipe_counter : uint16_t {
     MaliGPUActiveCy,
     MaliGPUIRQActiveCy,
     MaliFragQueueJob,


### PR DESCRIPTION
Modify the enum to a fixed size, making it easy for users to confirm its size during coding. For example, with hwcpipe_counter, users can conveniently create a default sampling counter array based on the actual size of the enum.